### PR TITLE
Trap CTRL-C so we can exit gracefully

### DIFF
--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -17,6 +17,13 @@ let total_length=$pomodoro_length+$break_length
 
 pomodoro=0
 
+trap ctrl_c INT
+
+function ctrl_c() {
+	$blink_path --off
+	exit 0
+}
+
 while true; do
 	echo "$pomodoro_secs"
 	let pomodoro+=1


### PR DESCRIPTION
Turns off the blink(1) when exiting through CTRL-C.
